### PR TITLE
Add 'var/config/portal' to shared dirs

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -47,6 +47,7 @@ set('shared_files', [
     'var/config/website-settings.php',
 ]);
 set('shared_dirs', [
+    'var/config/portal',
     'var/email',
     'var/recyclebin',
     'var/sessions',


### PR DESCRIPTION
Add 'var/config/portal' to shared dirs, so dashboard (portal) configuration for users don't get overwritten on every deployment