### PR TITLE
Feat/htaccess rules

### DIFF
--- a/config/packages/pimcore_admin.yaml
+++ b/config/packages/pimcore_admin.yaml
@@ -1,7 +1,5 @@
 # see https://pimcore.com/docs/pimcore/current/Development_Documentation/Best_Practice/Security_Concept.html#page_Content-Security-Policy
 #   and https://content-security-policy.com/#directive for more information
-# IMPORTANT: Please note enabling CSP headers for admin interface will make DataObject WYSIWYG editor menu unresponsive
-#   as CKeditor 4 does not completely support it.
 pimcore_admin:
     admin_csp_header:
         enabled: true

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -293,9 +293,10 @@ RewriteRule ^ %{ENV:BASE}/index.php [L]
     Header set Content-Security-Policy "default-src 'self';"
 
     # HTST
-    Header set Strict-Transport-Security "max-age=2592000; includeSubDomains;" # 2592000 = 30 days
+    Header set Strict-Transport-Security "max-age=300; includeSubDomains"
     # Preload feature (see https://hstspreload.org/) -> https://hstspreload.org/#deployment-recommendations
-#    Header set Strict-Transport-Security "max-age=300; includeSubDomains;"
+#    Header set Strict-Transport-Security "max-age=604800; includeSubDomains"
+#    Header set Strict-Transport-Security "max-age=2592000; includeSubDomains"
 #    Header set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 
 </IfModule>


### PR DESCRIPTION
Pimcore X supports a CSP header for the admin interface -> should we activate that by default? (config/packages/pimcore_admin.yaml)

The following changes (headers) need attention for new projects:
- X-Frame-Options
- Content-Security-Policy
- Strict-Transport-Security